### PR TITLE
Added correct plural for box -> boxes

### DIFF
--- a/Inflector.php
+++ b/Inflector.php
@@ -284,6 +284,9 @@ final class Inflector
         // indices (index)
         ['xedni', 5, false, true, ['indicies', 'indexes']],
 
+        // boxes (box)
+        ['xo', 2, false, true, 'oxes'],
+
         // indexes (index), matrixes (matrix)
         ['x', 1, true, false, ['cies', 'xes']],
 

--- a/Tests/InflectorTest.php
+++ b/Tests/InflectorTest.php
@@ -180,7 +180,7 @@ class InflectorTest extends TestCase
             ['batch', 'batches'],
             ['beau', ['beaus', 'beaux']],
             ['bee', 'bees'],
-            ['box', ['bocies', 'boxes']],
+            ['box', 'boxes'],
             ['boy', 'boys'],
             ['bureau', ['bureaus', 'bureaux']],
             ['bus', 'buses'],


### PR DESCRIPTION
I noticed there was even a test asserting a correct plural for box would be 'bocies'. A quick look in the dictionary to assure this isn't the case (https://www.merriam-webster.com/dictionary/box) sealed the fate of this test and inflection 😉